### PR TITLE
Add Google Vision OCR fallback when Document AI unavailable or low confidence

### DIFF
--- a/docs/DOCUMENT_AI_INTEGRATION_COMPLETE.md
+++ b/docs/DOCUMENT_AI_INTEGRATION_COMPLETE.md
@@ -23,7 +23,7 @@
 
 ### 1. Enhanced OCR Pipeline (`src/yolo_crop_ocr_pipeline.py`)
 - **Document AI as primary method** for ALL document types
-- **Smart fallback system**: Only uses Google Vision when Document AI has low confidence (< 0.3) or insufficient text
+- **Smart fallback system**: Uses Google Vision when Document AI fails, is disabled, or has confidence < 0.3
 - **Confidence-based decision making**: Compares results and uses the better one
 - **Comprehensive field extraction**: Extracts structured fields with confidence scores
 
@@ -90,7 +90,7 @@ python main.py  # Now uses Document AI as primary OCR method
 - **Structured Data**: Confidence scores for all extracted fields
 - **Better Field Mapping**: Document AI fields prioritized over raw OCR
 - **Multi-language Support**: Enhanced Arabic/English processing
-- **Fallback System**: Automatic fallback to Google Vision when needed
+- **Fallback System**: Automatic fallback to Google Vision when Document AI fails, is disabled, or returns confidence < 0.3
 
 ## 🔍 Technical Details
 
@@ -109,7 +109,7 @@ GOOGLE_APPLICATION_CREDENTIALS=config/GOOGLEAPI.json
 ### Integration Points
 1. **YOLO Cropping**: Documents are cropped first, then processed
 2. **Document AI Processing**: Primary OCR with field extraction
-3. **Confidence Validation**: Low confidence triggers Google Vision fallback
+3. **Fallback Handling**: Document AI errors, disabled state, or low confidence (< 0.3) trigger Google Vision fallback
 4. **Field Storage**: Extracted fields stored by document type
 5. **Gemini Structuring**: Document AI fields prioritized in final structuring
 

--- a/tests/test_ocr_fallback.py
+++ b/tests/test_ocr_fallback.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import types
+
+# Provide lightweight mocks for heavy optional dependencies
+sys.modules.setdefault('cv2', types.SimpleNamespace())
+
+class DummyYOLO:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return [types.SimpleNamespace(boxes=[])]
+
+sys.modules.setdefault('ultralytics', types.SimpleNamespace(YOLO=DummyYOLO))
+
+class DummyVisionClient:
+    def document_text_detection(self, image):
+        return types.SimpleNamespace(full_text_annotation=None, text_annotations=None, label_annotations=None)
+
+    def text_detection(self, image):
+        return types.SimpleNamespace(text_annotations=None)
+
+vision_stub = types.SimpleNamespace(
+    ImageAnnotatorClient=lambda: DummyVisionClient(),
+    Image=lambda **kwargs: types.SimpleNamespace(),
+)
+sys.modules.setdefault('google', types.SimpleNamespace(cloud=types.SimpleNamespace(vision=vision_stub)))
+sys.modules.setdefault('google.cloud', types.SimpleNamespace(vision=vision_stub))
+sys.modules.setdefault('google.cloud.vision', vision_stub)
+
+# Ensure src directory is on the path for imports
+sys.path.append('src')
+
+from yolo_crop_ocr_pipeline import run_enhanced_ocr
+
+
+def test_google_vision_fallback(monkeypatch, tmp_path):
+    """When Document AI is disabled, run_enhanced_ocr should use Google Vision."""
+    # Disable Document AI
+    monkeypatch.setattr("yolo_crop_ocr_pipeline.DOCUMENT_AI_AVAILABLE", False)
+
+    # Stub out Google Vision OCR to avoid external API calls
+    def fake_vision(path):
+        return {"ocr_text": "dummy"}
+
+    monkeypatch.setattr("yolo_crop_ocr_pipeline.run_google_vision_ocr", fake_vision)
+
+    # Call enhanced OCR with a dummy image path
+    dummy_path = tmp_path / "dummy.jpg"
+    result = run_enhanced_ocr(str(dummy_path))
+
+    assert result["ocr_method"] == "google_vision"
+    assert result["ocr_text"] == "dummy"
+
+
+def test_low_confidence_triggers_google_vision(monkeypatch, tmp_path):
+    """Low Document AI confidence should trigger Google Vision fallback."""
+
+    class DummyProcessor:
+        enabled = True
+
+        def process_document(self, path):
+            return {"full_text": "doc ai text", "confidence": 0.2}
+
+        def get_document_type(self, text):
+            return "passport"
+
+        def extract_fields_by_document_type(self, text):
+            return {}
+
+    monkeypatch.setattr("yolo_crop_ocr_pipeline.DOCUMENT_AI_AVAILABLE", True)
+    monkeypatch.setattr("yolo_crop_ocr_pipeline.DOCUMENT_AI_PROCESSOR", DummyProcessor())
+
+    def fake_vision(path):
+        return {"ocr_text": "vision"}
+
+    monkeypatch.setattr("yolo_crop_ocr_pipeline.run_google_vision_ocr", fake_vision)
+
+    dummy_path = tmp_path / "dummy.jpg"
+    result = run_enhanced_ocr(str(dummy_path))
+
+    assert result["ocr_method"] == "google_vision"
+    assert result["ocr_text"] == "vision"
+    assert result["confidence"] == 0.2


### PR DESCRIPTION
## Summary
- use Google Vision OCR when Document AI is disabled, errors, or reports confidence < 0.3
- label OCR method in metadata
- document fallback and add regression tests

## Testing
- `pytest tests/test_ocr_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68925087f4ac832fa261d670e26aa05b