### PR TITLE
Add GUI for full and manual document processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ A comprehensive document processing system for MOHRE (Ministry of Human Resource
    cp .env.example .env
    # edit .env with your API keys and project IDs
    ```
-4. Run the pipeline
+4. Launch the GUI
    ```bash
    python main.py
    ```
+   This opens a window where you can either run the full automated pipeline
+   over the downloads folder or manually select specific files for cropping
+   and OCR structuring.
 
 ## 🆕 What's New: Document AI Integration
 

--- a/gui_app.py
+++ b/gui_app.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""GUI application for MOHRE document processing."""
+
+import os
+import sys
+import shutil
+import threading
+import json
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+# Optional drag and drop support
+try:
+    from tkinterdnd2 import DND_FILES, TkinterDnD
+    TKDND_AVAILABLE = True
+except Exception:
+    TKDND_AVAILABLE = False
+
+# Ensure src directory is in path when running standalone
+if os.path.join(os.path.dirname(__file__), "src") not in sys.path:
+    sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
+
+from main_pipeline import main as run_full_pipeline
+from pdf_converter import convert_pdf_to_jpg
+from yolo_crop_ocr_pipeline import run_yolo_crop, run_enhanced_ocr
+from structure_with_gemini import structure_with_gemini
+
+TEMP_DIR = os.path.join("data", "temp")
+
+
+def run_gui():
+    """Launch the main GUI window."""
+    root = TkinterDnD.Tk() if TKDND_AVAILABLE else tk.Tk()
+    root.title("MOHRE Document Processor")
+    root.geometry("400x200")
+
+    tk.Label(root, text="Choose Processing Mode", font=("Arial", 14)).pack(pady=10)
+
+    tk.Button(
+        root,
+        text="Run Full Pipeline",
+        command=lambda: threading.Thread(target=run_full_pipeline, daemon=True).start(),
+        width=25,
+    ).pack(pady=10)
+
+    tk.Button(
+        root,
+        text="Manual File Processing",
+        command=lambda: ManualProcessingWindow(root),
+        width=25,
+    ).pack(pady=10)
+
+    root.mainloop()
+
+
+class ManualProcessingWindow(tk.Toplevel):
+    """Window for manual file processing."""
+
+    def __init__(self, master):
+        super().__init__(master)
+        self.title("Manual Processing")
+        self.geometry("500x400")
+        self.file_paths = []
+
+        self.file_area = tk.Frame(self, relief=tk.SUNKEN, borderwidth=1)
+        self.file_area.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        if TKDND_AVAILABLE:
+            self.file_area.drop_target_register(DND_FILES)
+            self.file_area.dnd_bind("<<Drop>>", self._drop_files)
+
+        button_frame = tk.Frame(self)
+        button_frame.pack(fill=tk.X, padx=10, pady=5)
+
+        tk.Button(button_frame, text="Add Files", command=self._browse_files).pack(side=tk.LEFT)
+        self.start_button = tk.Button(
+            button_frame, text="Start Processing", command=self._start_processing, state=tk.DISABLED
+        )
+        self.start_button.pack(side=tk.RIGHT)
+
+        self.status_label = tk.Label(self, text="")
+        self.status_label.pack(pady=5)
+
+    def _browse_files(self):
+        paths = filedialog.askopenfilenames(
+            filetypes=[("Documents", "*.pdf *.jpg *.jpeg *.png"), ("All Files", "*.*")]
+        )
+        self._add_files(paths)
+
+    def _drop_files(self, event):
+        paths = self.tk.splitlist(event.data)
+        self._add_files(paths)
+
+    def _add_files(self, paths):
+        for path in paths:
+            if path and path not in self.file_paths:
+                self.file_paths.append(path)
+                self._add_file_widget(path)
+        if self.file_paths:
+            self.start_button.config(state=tk.NORMAL)
+
+    def _add_file_widget(self, path):
+        row = tk.Frame(self.file_area)
+        row.pack(fill=tk.X, padx=5, pady=2)
+        tk.Label(row, text=os.path.basename(path), anchor="w").pack(side=tk.LEFT, fill=tk.X, expand=True)
+        tk.Button(row, text="X", command=lambda p=path, r=row: self._remove_file(p, r)).pack(side=tk.RIGHT)
+
+    def _remove_file(self, path, row):
+        if path in self.file_paths:
+            self.file_paths.remove(path)
+            row.destroy()
+        if not self.file_paths:
+            self.start_button.config(state=tk.DISABLED)
+
+    def _start_processing(self):
+        output_dir = filedialog.askdirectory(title="Select Output Directory")
+        if not output_dir:
+            output_dir = os.path.join("data", "processed", "manual")
+        os.makedirs(output_dir, exist_ok=True)
+
+        threading.Thread(
+            target=self._process_files, args=(self.file_paths.copy(), output_dir), daemon=True
+        ).start()
+        self.status_label.config(text="Processing...")
+
+    def _process_files(self, paths, output_dir):
+        os.makedirs(TEMP_DIR, exist_ok=True)
+        for file_path in paths:
+            try:
+                images = []
+                if file_path.lower().endswith(".pdf"):
+                    images = convert_pdf_to_jpg(file_path, TEMP_DIR)
+                else:
+                    temp_path = os.path.join(TEMP_DIR, os.path.basename(file_path))
+                    shutil.copy2(file_path, temp_path)
+                    images = [temp_path]
+
+                for img in images:
+                    cropped = run_yolo_crop(img, TEMP_DIR)
+                    ocr = run_enhanced_ocr(cropped)
+                    structured = structure_with_gemini(
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        ocr.get("ocr_text", ""),
+                        {},
+                        "",
+                        "manual",
+                        {},
+                    )
+                    out_name = os.path.splitext(os.path.basename(img))[0] + "_output.json"
+                    out_path = os.path.join(output_dir, out_name)
+                    with open(out_path, "w", encoding="utf-8") as f:
+                        json.dump(structured, f, ensure_ascii=False, indent=2)
+            except Exception as e:
+                print(f"Error processing {file_path}: {e}")
+        self.status_label.config(text="Processing complete")
+        messagebox.showinfo("MOHRE", "Manual processing completed")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run_gui()

--- a/main.py
+++ b/main.py
@@ -21,14 +21,7 @@ else:
 # Add src directory to path
 sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
 
-from main_pipeline import main
+from gui_app import run_gui
 
 if __name__ == "__main__":
-    from datetime import datetime
-    import time
-
-    while True:
-        print(f"\n🔄 Starting processing cycle at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
-        main()
-        print("⏳ Sleeping for 5 minutes before next cycle...\n")
-        time.sleep(5 * 60)
+    run_gui()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ pdf2image
 python-docx
 python-dotenv
 pytest
+tkinterdnd2
 


### PR DESCRIPTION
## Summary
- Replace console loop with a GUI entry point in `main.py`.
- Add `gui_app.py` providing buttons for full pipeline and manual file handling with drag-and-drop support.
- Extend manual mode to crop images, run OCR, structure results and save outputs.
- Document new GUI launch steps and include `tkinterdnd2` dependency.

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ImportError: libGL.so.1, DefaultCredentialsError)*

------
https://chatgpt.com/codex/tasks/task_e_6892e5778c34832f8fb7e85b33f04aee