### PR TITLE
Add PyMuPDF dependency for PDF processing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ ultralytics
 
 # Tooling
 pdf2image
+pymupdf
 python-docx
 python-dotenv
 pytest


### PR DESCRIPTION
## Summary
- add `pymupdf` dependency for PDF text extraction

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_ahmad_pdf_conversion.py::test_pdf_conversion_and_vision -q`
- `python - <<'PY'
import fitz
print('PyMuPDF version', fitz.__doc__)
doc=fitz.open(); page=doc.new_page(); page.insert_text((72,72), 'Hello PyMuPDF'); doc.save('sample.pdf'); doc.close();
with fitz.open('sample.pdf') as doc:
    text=''.join(page.get_text() for page in doc)
    print('Extracted:', text.strip())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6892f0ff048c832f86396248c35588d1