### PR TITLE
feat: centralize configuration

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,22 +6,22 @@ Main Entry Point
 
 import sys
 import os
-from dotenv import load_dotenv
-
-load_dotenv()
-
-# Set Google API credentials automatically
-google_creds_path = os.path.join(os.path.dirname(__file__), 'config', 'GOOGLEAPI.json')
-if os.path.exists(google_creds_path):
-    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = google_creds_path
-    print(f"✅ Google API credentials set: {google_creds_path}")
-else:
-    print(f"⚠️ Warning: Google API credentials file not found at {google_creds_path}")
 
 # Add src directory to path
 sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
 
+from config import get_config
 from gui_app import run_gui
+
+config = get_config()
+
+# Set Google API credentials automatically
+google_creds_path = config.google_application_credentials
+if google_creds_path and google_creds_path.exists():
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(google_creds_path)
+    print(f"✅ Google API credentials set: {google_creds_path}")
+else:
+    print(f"⚠️ Warning: Google API credentials file not found at {google_creds_path}")
 
 if __name__ == "__main__":
     run_gui()

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -5,15 +5,15 @@ from PIL import Image
 from pdf2image import convert_from_path
 import os
 from pathlib import Path
-from dotenv import load_dotenv
+from config import get_config
 
 # === CONFIG ===
-load_dotenv()
+config = get_config()
 BASE_DIR = Path(__file__).resolve().parents[1]
-MODEL_PATH = os.getenv("MODEL_PATH", "model_classifier.pt")  # Updated model path
+MODEL_PATH = str(config.model_path)  # Updated model path
 IMG_SIZE = 224
-ROOT_DIR = Path(os.getenv("ROOT_DIR", BASE_DIR / "data" / "raw" / "downloads"))
-DATASET_DIR = Path(os.getenv("DATASET_DIR", BASE_DIR / "data" / "dataset"))
+ROOT_DIR = config.root_dir
+DATASET_DIR = config.dataset_dir
 TEMP_JPG_PATH = "temp_passport_page.jpg"
 
 # === Disable DecompressionBombWarning ===

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+import os
+from dotenv import load_dotenv
+
+# Base directory of the project
+BASE_DIR = Path(__file__).resolve().parents[1]
+
+# Load environment variables once
+load_dotenv()
+
+
+@dataclass
+class Config:
+    """Application configuration loaded from environment variables."""
+
+    # API Keys
+    google_api_key: Optional[str] = os.getenv("GOOGLE_API_KEY")
+    gemini_api_key: Optional[str] = os.getenv("GEMINI_API_KEY")
+    google_cloud_project_id: Optional[str] = os.getenv("GOOGLE_CLOUD_PROJECT_ID")
+    document_ai_processor_id: Optional[str] = os.getenv("DOCUMENT_AI_PROCESSOR_ID")
+
+    # Paths
+    yolo_model_path: Path = Path(os.getenv("YOLO_MODEL_PATH", BASE_DIR / "models" / "yolo8_best.pt"))
+    input_root: Path = Path(os.getenv("INPUT_ROOT", BASE_DIR / "data" / "dataset"))
+    output_root: Path = Path(os.getenv("OUTPUT_ROOT", BASE_DIR / "data" / "processed" / "COMPLETED"))
+    data_dir: Path = Path(os.getenv("DATA_DIR", BASE_DIR / "data" / "dataset"))
+    model_save_path: Path = Path(os.getenv("MODEL_SAVE_PATH", BASE_DIR / "models" / "model_classifier.pt"))
+    dataset_classes_path: Path = Path(os.getenv("DATASET_CLASSES_PATH", BASE_DIR / "data" / "dataset"))
+    input_dir: Path = Path(os.getenv("INPUT_DIR", BASE_DIR / "data" / "raw" / "downloads"))
+    output_dir: Path = Path(os.getenv("OUTPUT_DIR", BASE_DIR / "data" / "processed" / "MOHRE_ready"))
+    model_path: Path = Path(os.getenv("MODEL_PATH", BASE_DIR / "models" / "model_classifier.pt"))
+    root_dir: Path = Path(os.getenv("ROOT_DIR", BASE_DIR / "data" / "raw" / "downloads"))
+    dataset_dir: Path = Path(os.getenv("DATASET_DIR", BASE_DIR / "data" / "dataset"))
+    source_yolo_model: Path = Path(os.getenv("SOURCE_YOLO_MODEL", BASE_DIR / "models" / "yolo8_best.pt"))
+    source_classifier_model: Path = Path(os.getenv("SOURCE_CLASSIFIER_MODEL", BASE_DIR / "models" / "classifier.pt"))
+    source_dataset: Path = Path(os.getenv("SOURCE_DATASET", BASE_DIR / "data" / "dataset"))
+    google_application_credentials: Path = Path(
+        os.getenv("GOOGLE_APPLICATION_CREDENTIALS", BASE_DIR / "config" / "GOOGLEAPI.json")
+    )
+    passport_image_path: Path = Path(
+        os.getenv(
+            "PASSPORT_IMAGE_PATH",
+            BASE_DIR / "data" / "processed" / "COMPLETED" / "passport_1" / "sample_passport.jpg",
+        )
+    )
+    email_address: Optional[str] = os.getenv("EMAIL_ADDRESS")
+    email_password: Optional[str] = os.getenv("EMAIL_PASSWORD")
+    imap_server: Optional[str] = os.getenv("IMAP_SERVER")
+    download_dir: Path = Path(os.getenv("DOWNLOAD_DIR", BASE_DIR / "data" / "raw" / "downloads"))
+
+
+@lru_cache()
+def get_config() -> Config:
+    """Return a cached configuration instance."""
+    cfg = Config()
+    if cfg.google_application_credentials and not os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(cfg.google_application_credentials)
+    return cfg
+

--- a/src/copy_models_and_dataset.py
+++ b/src/copy_models_and_dataset.py
@@ -7,9 +7,9 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from dotenv import load_dotenv
+from config import get_config
 
-load_dotenv()
+config = get_config()
 
 def copy_models_and_dataset():
     """Copy trained models and dataset to MOHRE folder."""
@@ -20,9 +20,9 @@ def copy_models_and_dataset():
     base_dir = Path(__file__).resolve().parents[1]
 
     # Source paths (can be overridden via environment variables)
-    source_yolo_model = Path(os.getenv("SOURCE_YOLO_MODEL", base_dir / "models" / "yolo8_best.pt"))
-    source_classifier_model = Path(os.getenv("SOURCE_CLASSIFIER_MODEL", base_dir / "models" / "classifier.pt"))
-    source_dataset = Path(os.getenv("SOURCE_DATASET", base_dir / "data" / "dataset"))
+    source_yolo_model = config.source_yolo_model
+    source_classifier_model = config.source_classifier_model
+    source_dataset = config.source_dataset
 
     # Destination paths in MOHRE folder
     dest_models_dir = base_dir / "models"

--- a/src/crop_yolo_detections.py
+++ b/src/crop_yolo_detections.py
@@ -1,21 +1,19 @@
 from ultralytics import YOLO
 import cv2
 import os
-from pathlib import Path
-from dotenv import load_dotenv
+from config import get_config
 
 # === CONFIGURATION ===
-load_dotenv()
-base_dir = Path(__file__).resolve().parents[1]
-model_path = os.getenv("YOLO_MODEL_PATH", str(base_dir / "models" / "yolo8_best.pt"))
-input_root = os.getenv("INPUT_ROOT", str(base_dir / "data" / "dataset"))
-output_root = os.getenv("OUTPUT_ROOT", str(base_dir / "data" / "processed" / "COMPLETED"))
+config = get_config()
+model_path = config.yolo_model_path
+input_root = config.input_root
+output_root = config.output_root
 
 # Load model
-model = YOLO(model_path)
+model = YOLO(str(model_path))
 
 # Recursively walk through subfolders
-for root, _, files in os.walk(input_root):
+for root, _, files in os.walk(str(input_root)):
     for filename in files:
         if filename.lower().endswith(('.jpg', '.png', '.jpeg')):
             input_path = os.path.join(root, filename)

--- a/src/document_ai_processor.py
+++ b/src/document_ai_processor.py
@@ -7,18 +7,17 @@ Handles structured document processing using Document OCR Processor
 import os
 import json
 from typing import Dict, List, Optional, Tuple
-from dotenv import load_dotenv
-
-load_dotenv()
+from config import get_config
 
 class DocumentAIProcessor:
     """Google Document AI processor using Document OCR Processor"""
     
     def __init__(self):
         """Initialize Document AI client and processor"""
-        # Get processor details from environment
-        self.project_id = os.getenv('GOOGLE_CLOUD_PROJECT_ID')
-        self.processor_id = os.getenv('DOCUMENT_AI_PROCESSOR_ID')
+        # Get processor details from configuration
+        config = get_config()
+        self.project_id = config.google_cloud_project_id
+        self.processor_id = config.document_ai_processor_id
         self.location = "us"  # Default location
         
         if not self.project_id or not self.processor_id:

--- a/src/document_processor_v5.py
+++ b/src/document_processor_v5.py
@@ -7,16 +7,16 @@ import torchvision.transforms as transforms
 from torchvision import models
 import fitz  # from PyMuPDF
 from pathlib import Path
-from dotenv import load_dotenv
+from config import get_config
 
 
 # === CONFIG ===
-load_dotenv()
+config = get_config()
 BASE_DIR = Path(__file__).resolve().parents[1]
-DATASET_CLASSES_PATH = Path(os.getenv("DATASET_CLASSES_PATH", BASE_DIR / "data" / "dataset"))
-INPUT_DIR = Path(os.getenv("INPUT_DIR", BASE_DIR / "data" / "raw" / "downloads"))
-OUTPUT_DIR = Path(os.getenv("OUTPUT_DIR", BASE_DIR / "data" / "processed" / "MOHRE_ready"))
-MODEL_PATH = Path(os.getenv("MODEL_PATH", BASE_DIR / "models" / "model_classifier.pt"))
+DATASET_CLASSES_PATH = config.dataset_classes_path
+INPUT_DIR = config.input_dir
+OUTPUT_DIR = config.output_dir
+MODEL_PATH = config.model_path
 TEMP_JPG = "temp.jpg"
 IMG_SIZE = 224
 MAX_OUTPUT_KB = 110

--- a/src/email_parser.py
+++ b/src/email_parser.py
@@ -5,16 +5,16 @@ import time
 import shutil
 from email.header import decode_header
 from email.utils import parseaddr
-from dotenv import load_dotenv
 from datetime import datetime
+from config import get_config
 
 # Load environment variables
-load_dotenv()
+config = get_config()
 
-EMAIL = os.getenv("EMAIL_ADDRESS")
-PASSWORD = os.getenv("EMAIL_PASSWORD")
-IMAP_SERVER = os.getenv("IMAP_SERVER")
-DOWNLOAD_DIR = os.getenv("DOWNLOAD_DIR", "data/raw/downloads")
+EMAIL = config.email_address
+PASSWORD = config.email_password
+IMAP_SERVER = config.imap_server
+DOWNLOAD_DIR = str(config.download_dir)
 
 os.makedirs(DOWNLOAD_DIR, exist_ok=True)
 

--- a/src/enhanced_document_processor.py
+++ b/src/enhanced_document_processor.py
@@ -14,19 +14,19 @@ import cv2
 import numpy as np
 from ultralytics import YOLO
 from google.cloud import documentai_v1 as documentai
-from dotenv import load_dotenv
+from config import get_config
 
 # Import simple Google Vision orientation detection
 from google_vision_orientation_detector import rotate_if_needed
 from yolo_crop_ocr_pipeline import run_google_vision_ocr
 
-# Load environment variables
-load_dotenv()
+# Load configuration
+config = get_config()
 
 # Set Google Application Credentials for Document AI
-google_creds_path = os.path.join(os.path.dirname(__file__), '..', 'config', 'GOOGLEAPI.json')
-if os.path.exists(google_creds_path):
-    os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = google_creds_path
+google_creds_path = config.google_application_credentials
+if google_creds_path and google_creds_path.exists():
+    os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = str(google_creds_path)
     print(f"✅ Document AI credentials set: {google_creds_path}")
 else:
     print(f"⚠️ Document AI credentials not found at: {google_creds_path}")
@@ -253,7 +253,10 @@ class EnhancedDocumentProcessor:
                 image_content = image.read()
 
             # Configure the process request
-            name = f"projects/{os.getenv('GOOGLE_CLOUD_PROJECT_ID')}/locations/us/processors/{os.getenv('DOCUMENT_AI_PROCESSOR_ID')}"
+            name = (
+                f"projects/{config.google_cloud_project_id}/locations/us/"
+                f"processors/{config.document_ai_processor_id}"
+            )
 
             raw_document = documentai.RawDocument(content=image_content, mime_type="image/jpeg")
             request = documentai.ProcessRequest(name=name, raw_document=raw_document)

--- a/src/google_ai_rotation.py
+++ b/src/google_ai_rotation.py
@@ -11,11 +11,11 @@ import base64
 import google.generativeai as genai
 from PIL import Image
 import io
-from dotenv import load_dotenv
+from config import get_config
 
 # Configure Google Gemini API
-load_dotenv()
-genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
+config = get_config()
+genai.configure(api_key=config.gemini_api_key)
 
 # Only rotate these document types
 ROTATABLE_CLASSES = {"passport_1", "passport_2", "personal_photo", "certificate"}

--- a/src/google_vision_orientation_detector.py
+++ b/src/google_vision_orientation_detector.py
@@ -9,9 +9,9 @@ import base64
 import json
 import google.generativeai as genai
 import cv2
-from dotenv import load_dotenv
+from config import get_config
 
-load_dotenv()
+config = get_config()
 
 def ask_gemini_if_needs_rotation(image_path: str) -> dict:
     """
@@ -25,7 +25,7 @@ def ask_gemini_if_needs_rotation(image_path: str) -> dict:
     """
     try:
         # Configure Gemini
-        genai.configure(api_key=os.getenv('GOOGLE_API_KEY'))
+        genai.configure(api_key=config.google_api_key)
         
         # Use Gemini 2.5 Flash
         model = genai.GenerativeModel('gemini-2.5-flash')

--- a/src/mobilenet_training.py
+++ b/src/mobilenet_training.py
@@ -8,13 +8,13 @@ import torch.nn as nn
 import torch.optim as optim
 from datetime import datetime
 from pathlib import Path
-from dotenv import load_dotenv
+from config import get_config
 
 # Config
-load_dotenv()
+config = get_config()
 BASE_DIR = Path(__file__).resolve().parents[1]
-DATA_DIR = os.getenv("DATA_DIR", str(BASE_DIR / "data" / "dataset"))
-MODEL_SAVE_PATH = os.getenv("MODEL_SAVE_PATH", "model_classifier.pt")
+DATA_DIR = str(config.data_dir)
+MODEL_SAVE_PATH = str(config.model_save_path)
 BATCH_SIZE = 8
 EPOCHS = 15
 LEARNING_RATE = 0.001

--- a/src/passport_ocr_processor.py
+++ b/src/passport_ocr_processor.py
@@ -1,16 +1,16 @@
 import os
 import io
-from dotenv import load_dotenv
 from google.cloud import vision
 import google.generativeai as genai
 from pathlib import Path
+from config import get_config
 
-# === Step 1: Load environment variables from .env ===
-load_dotenv()
+# === Step 1: Load configuration ===
+config = get_config()
 
 # ✅ Set credentials from environment
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
-genai.configure(api_key=os.getenv("GOOGLE_API_KEY"))
+os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(config.google_application_credentials)
+genai.configure(api_key=config.google_api_key)
 
 # === Step 2: Use Google Vision to extract text from image ===
 def extract_text_with_google_vision(image_path):
@@ -54,9 +54,7 @@ OCR TEXT:
 # === Step 4: Run everything ===
 def main():
     # 🖼️ Image path can be configured via environment variable
-    base_dir = Path(__file__).resolve().parents[1]
-    default_path = base_dir / "data" / "processed" / "COMPLETED" / "passport_1" / "sample_passport.jpg"
-    image_path = os.getenv("PASSPORT_IMAGE_PATH", str(default_path))
+    image_path = str(config.passport_image_path)
 
     print("🔍 Extracting text with Google Vision...")
     ocr_text = extract_text_with_google_vision(image_path)

--- a/src/resnet18_classifier.py
+++ b/src/resnet18_classifier.py
@@ -8,17 +8,16 @@ from torchvision import models
 from PIL import Image
 import google.generativeai as genai
 from pathlib import Path
-from dotenv import load_dotenv
-
-load_dotenv()
+from config import get_config
 
 # Configure Google Gemini API
-genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
+config = get_config()
+genai.configure(api_key=config.gemini_api_key)
 
 # === CONFIG ===
 BASE_DIR = Path(__file__).resolve().parents[1]
-DATASET_DIR = os.getenv("DATASET_DIR", str(BASE_DIR / "data" / "dataset"))
-MODEL_PATH = os.getenv("MODEL_PATH", str(BASE_DIR / "models" / "classifier.pt"))
+DATASET_DIR = str(config.dataset_dir)
+MODEL_PATH = str(config.model_path)
 
 # === Auto-detect class names from folders ===
 CLASS_NAMES = sorted([

--- a/src/service_detector.py
+++ b/src/service_detector.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+from config import get_config
 
 # Optional third-party imports; module works with standard library if unavailable
 try:  # pragma: no cover - requests may not be installed in minimal environments
@@ -20,7 +21,8 @@ except Exception:  # pragma: no cover
     genai = None
 
 # Configure Gemini API if available
-api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+config = get_config()
+api_key = config.google_api_key or config.gemini_api_key
 if api_key and genai:
     genai.configure(api_key=api_key)
 

--- a/src/structure_with_gemini.py
+++ b/src/structure_with_gemini.py
@@ -1,7 +1,7 @@
 import google.generativeai as genai
 import os
 import json
-from dotenv import load_dotenv
+from config import get_config
 try:
     from attestation_utils import validate_attestation_numbers
 except ImportError:
@@ -10,8 +10,8 @@ except ImportError:
         return extracted_numbers
 
 # Configure Google Gemini API
-load_dotenv()
-genai.configure(api_key=os.getenv("GOOGLE_API_KEY"))
+config = get_config()
+genai.configure(api_key=config.google_api_key)
 
 def structure_with_gemini(
     passport_ocr_1: str,

--- a/src/yolo_crop_ocr_pipeline.py
+++ b/src/yolo_crop_ocr_pipeline.py
@@ -2,12 +2,9 @@ import os
 import io
 import cv2
 import numpy as np
-from dotenv import load_dotenv
 from ultralytics import YOLO
 from google.cloud import vision
-
-# Load environment variables first
-load_dotenv()
+from config import get_config
 
 # Import Document AI processor
 try:
@@ -18,12 +15,9 @@ except ImportError as e:
     DOCUMENT_AI_AVAILABLE = False
     print(f"⚠️ Document AI not available: {e}")
 
-# === LOAD .env VARIABLES ===
-load_dotenv()
-
 # === CONFIG ===
-YOLO_MODEL_PATH = "models/yolo8_best.pt"
-YOLO_MODEL = YOLO(YOLO_MODEL_PATH)
+config = get_config()
+YOLO_MODEL = YOLO(str(config.yolo_model_path))
 
 VISION_CLIENT = vision.ImageAnnotatorClient()
 


### PR DESCRIPTION
## Summary
- add centralized Config dataclass for environment-driven paths, API keys, and credentials
- refactor modules to consume shared configuration via `get_config()` instead of individual `load_dotenv` calls

## Testing
- `pytest -q` *(fails: libGL.so.1 missing; GOOGLEAPI.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892f55e1bec832f8b07734765a89b65