### PR TITLE
Add offline unit tests for utility helpers

### DIFF
--- a/tests/unit/test_document_processing_validations.py
+++ b/tests/unit/test_document_processing_validations.py
@@ -1,0 +1,69 @@
+import sys
+import pathlib
+import types
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'src'))
+
+
+@pytest.fixture(scope='module')
+def validations():
+    sys.modules['yolo_crop_ocr_pipeline'] = types.SimpleNamespace(
+        run_yolo_crop=lambda *a, **k: None,
+        run_enhanced_ocr=lambda *a, **k: None,
+    )
+    sys.modules['image_rotation_utils'] = types.SimpleNamespace(
+        rotate_image_if_needed=lambda *a, **k: None,
+    )
+    sys.modules['resnet18_classifier'] = types.SimpleNamespace(
+        classify_image_resnet=lambda *a, **k: None,
+        classify_image_from_text=lambda *a, **k: None,
+        classify_image_with_gemini_vision=lambda *a, **k: None,
+        check_image_orientation=lambda *a, **k: None,
+        auto_rotate_image_if_needed=lambda *a, **k: None,
+    )
+    import document_processing_pipeline as dpp
+    return dpp
+
+
+@pytest.fixture
+def passport_text():
+    return 'Passport No A12345678 given name John date of birth 1990'
+
+
+@pytest.fixture
+def eid_text():
+    return 'Emirates ID 784-1234-1234567-1 identity card holder'
+
+
+@pytest.fixture
+def certificate_text():
+    return 'This is to certify that Jane Doe has completed Bachelor degree certificate no. 1234567890'
+
+
+@pytest.fixture
+def attestation_text():
+    return 'Document attestation by Ministry of Foreign Affairs attestation no. 1234567890'
+
+
+def test_validate_passport_in_certificate(validations, passport_text):
+    assert validations.validate_passport_in_certificate(passport_text)
+    assert not validations.validate_passport_in_certificate('random text')
+
+
+def test_validate_emirates_id_in_certificate(validations, eid_text):
+    assert validations.validate_emirates_id_in_certificate(eid_text)
+
+
+def test_validate_certificate_in_emirates_id(validations, certificate_text):
+    assert validations.validate_certificate_in_emirates_id(certificate_text)
+
+
+def test_validate_attestation_in_certificate(validations, attestation_text):
+    assert validations.validate_attestation_in_certificate(attestation_text)
+
+
+def test_validate_attestation_label_detection(validations, attestation_text):
+    assert validations.validate_attestation_label_detection(['attestation_label'], attestation_text)
+    assert not validations.validate_attestation_label_detection(['attestation_label'], 'no attestation here')
+    assert not validations.validate_attestation_label_detection([], attestation_text)

--- a/tests/unit/test_image_utils_unit.py
+++ b/tests/unit/test_image_utils_unit.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import pathlib
+import numpy as np
+import cv2
+import pytest
+
+# Ensure src is importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'src'))
+
+from image_utils import (
+    compress_image_to_jpg,
+    crop_passport_1_to_passport_2,
+    resize_image,
+    enhance_image_quality,
+)
+
+
+@pytest.fixture
+def sample_image(tmp_path):
+    path = tmp_path / 'sample.jpg'
+    img = np.full((1000, 1000, 3), 255, dtype=np.uint8)
+    cv2.imwrite(str(path), img)
+    return str(path)
+
+
+@pytest.fixture
+def large_image(tmp_path):
+    path = tmp_path / 'large.jpg'
+    img = np.full((2000, 3000, 3), 255, dtype=np.uint8)
+    cv2.imwrite(str(path), img)
+    return str(path)
+
+
+def test_compress_image_to_jpg_reduces_size(sample_image, tmp_path):
+    out_path = tmp_path / 'compressed.jpg'
+    result = compress_image_to_jpg(sample_image, str(out_path), max_kb=50)
+    assert result == str(out_path)
+    assert out_path.exists()
+    assert os.path.getsize(out_path) / 1024 <= 50
+
+
+def test_compress_image_to_jpg_invalid_path(tmp_path):
+    missing = tmp_path / 'missing.jpg'
+    out_path = tmp_path / 'out.jpg'
+    result = compress_image_to_jpg(str(missing), str(out_path))
+    assert result == str(missing)
+
+
+def test_crop_passport_1_to_passport_2(sample_image, tmp_path):
+    result = crop_passport_1_to_passport_2(sample_image, str(tmp_path))
+    assert result is not None
+    img = cv2.imread(result)
+    assert img.shape[0] == 500
+    assert img.shape[1] == 1000
+
+
+def test_crop_passport_1_to_passport_2_invalid(tmp_path):
+    result = crop_passport_1_to_passport_2(str(tmp_path / 'missing.jpg'), str(tmp_path))
+    assert result is None
+
+
+def test_resize_image_downscales(large_image, tmp_path):
+    out_path = tmp_path / 'resized.jpg'
+    result = resize_image(large_image, str(out_path))
+    assert result == str(out_path)
+    img = cv2.imread(result)
+    assert img.shape[1] <= 1920
+    assert img.shape[0] <= 1080
+
+
+def test_resize_image_invalid_path(tmp_path):
+    result = resize_image(str(tmp_path / 'missing.jpg'), str(tmp_path / 'out.jpg'))
+    assert result == str(tmp_path / 'missing.jpg')
+
+
+def test_enhance_image_quality_creates_file(sample_image, tmp_path):
+    out_path = tmp_path / 'enhanced.jpg'
+    result = enhance_image_quality(sample_image, str(out_path))
+    assert result == str(out_path)
+    assert out_path.exists()
+
+
+def test_enhance_image_quality_invalid_path(tmp_path):
+    result = enhance_image_quality(str(tmp_path / 'missing.jpg'), str(tmp_path / 'out.jpg'))
+    assert result == str(tmp_path / 'missing.jpg')

--- a/tests/unit/test_output_saving_utils.py
+++ b/tests/unit/test_output_saving_utils.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import pathlib
+import json
+import shutil
+import numpy as np
+import cv2
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'src'))
+
+from output_saving_utils import save_outputs, log_processed_file
+
+
+@pytest.fixture
+def sample_image(tmp_path):
+    path = tmp_path / 'input.jpg'
+    img = np.full((100, 100, 3), 255, dtype=np.uint8)
+    cv2.imwrite(str(path), img)
+    return str(path)
+
+
+def test_save_outputs_success(sample_image, tmp_path):
+    output_dir = tmp_path / 'out'
+    result = save_outputs(sample_image, {'a': 1}, str(output_dir), 'base')
+    assert result == str(output_dir / 'base.jpg')
+    assert (output_dir / 'base.json').exists()
+
+
+def test_save_outputs_copy_failure(monkeypatch, sample_image, tmp_path):
+    def broken_copy(src, dst):
+        raise OSError('fail')
+    monkeypatch.setattr(shutil, 'copy2', broken_copy)
+    with pytest.raises(RuntimeError):
+        save_outputs(sample_image, {}, str(tmp_path), 'base')
+
+
+def test_log_processed_file(tmp_path):
+    log_file = tmp_path / 'log.txt'
+    log_processed_file(str(log_file), 'orig.pdf', 'out.jpg', 'passport')
+    text = log_file.read_text()
+    assert 'orig.pdf' in text
+    assert 'passport' in text


### PR DESCRIPTION
## Summary
- Add pytest coverage for image utilities such as JPEG compression, cropping, resizing and enhancement
- Test output saving helpers and logging with mocked file copy errors
- Validate pure document classification helpers without hitting external APIs

## Testing
- `pytest tests/unit/test_image_utils_unit.py tests/unit/test_output_saving_utils.py tests/unit/test_document_processing_validations.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892f5773428832fa2905b609f330e37